### PR TITLE
Add email templates and template substitution data to email handler file

### DIFF
--- a/apps/backend/emails/co-proposer-invite.html.pug
+++ b/apps/backend/emails/co-proposer-invite.html.pug
@@ -1,0 +1,17 @@
+//- Subject: Register for Diamond Light Source To Recipients: afakeperson@test.ac.uk Cc Recipients: eight@testing.ac.uk
+
+<p>Dear colleague,</p>
+
+<p>I would like to add you to a Proposal/Session at Diamond Light Source, unfortunately I am unable to find you in their system.</p>
+
+<p>If you are already registered with the Diamond UAS, can you please confirm your contact details with me. If you are not registered, can you please do so using the following link and then contact me so that I can add you to the proposal/session.</p>
+
+<p>
+    <a href="http://uasqa2.diamond.ac.uk:8080/uas/register">http://uasqa2.diamond.ac.uk:8080/uas/register</a>
+</p>
+
+<p>Please note, you will need to be registered and have passed the Diamond Safety Test to participate in an experimental session.</p>
+
+<p>Once registered, you can take the Diamond Safety Test here <a href="https://www.diamond.ac.uk/Users/Experiment-at-Diamond/Before-you-Arrive/Safety-Video-and-Test.html">https://www.diamond.ac.uk/Users/Experiment-at-Diamond/Before-you-Arrive/Safety-Video-and-Test.html</a>.</p>
+
+<p>Thank you,<br>#{sender}</p>

--- a/apps/backend/emails/co-proposer-invite.subject.pug
+++ b/apps/backend/emails/co-proposer-invite.subject.pug
@@ -1,0 +1,1 @@
+= `Register for Diamond Light Source`

--- a/apps/backend/emails/proposal-submitted.html.pug
+++ b/apps/backend/emails/proposal-submitted.html.pug
@@ -1,0 +1,33 @@
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+<p>Dear #{name},</p>
+
+<p>You have been included on a proposal at Diamond Light Source by #{proposal.principal_investigator}, #{proposal.establishment}. The proposal details are as follows:</p>
+
+<p>
+    <strong>Proposal title:</strong> #{proposal.title}<br />
+    <strong>Proposal Reference No:</strong> #{proposal.ref_num}<br />
+    <strong>Access Route:</strong> #{proposal.access_route}<br />
+    <strong>Submitted On:</strong> #{proposal.submitted_on}<br />
+    <strong>Principal Investigator:</strong> #{proposal.principal_investigator}, #{proposal.establishment}<br />
+    <strong>Alternate Contact(s):</strong> #{proposal.alternative_contacts ? proposal.alternative_contacts  : 'No AC\'s provided'}<br />
+    <strong>Co-investigator(s):</strong> #{proposal.coinvestigators}<br />
+    <strong>Requested: </strong> #{proposal.requested}<br />
+    <strong>Full Details:</strong> <a href="https://diamond.ac.uk">Click Here (Login required)</a>
+</p>
+
+<p>This proposal will be considered for the allocation period #{allocation_period}, along with the other proposals submitted by #{deadline}.</p>
+
+<p>You will not be able to edit your proposal now it has been submitted. If essential changes are needed, please contact the Diamond User Office by <a href="mailto:useroffice@diamond.ac.uk">email</a>.</p>
+<p>Your details will be stored on a database for use by Diamond Light Source.</p>
+<p>If you wish to withdraw your involvement in proposals or wish your name to be removed from the database, please contact Diamond User Office by <a href="mailto:useroffice@diamond.ac.uk">email.</a></p>
+<p>Regards,</p>
+<p>
+    | User Office <br />
+    | Diamond Light Source <br />
+    | Harwell Campus <br />
+    | Didcot <br />
+    | OX11 0DE <br />
+    | Tel: 01235 778571 <br />
+    | Email: <a href="mailto:useroffice@diamond.ac.uk">useroffice@diamond.ac.uk</a>
+</p>

--- a/apps/backend/emails/proposal-submitted.html.pug
+++ b/apps/backend/emails/proposal-submitted.html.pug
@@ -2,21 +2,21 @@
 
 <p>Dear #{name},</p>
 
-<p>You have been included on a proposal at Diamond Light Source by #{proposal.principal_investigator}, #{proposal.establishment}. The proposal details are as follows:</p>
+<p>You have been included on a proposal at Diamond Light Source by #{proposal.principalInvestigator}, #{proposal.establishment}. The proposal details are as follows:</p>
 
 <p>
     <strong>Proposal title:</strong> #{proposal.title}<br />
-    <strong>Proposal Reference No:</strong> #{proposal.ref_num}<br />
-    <strong>Access Route:</strong> #{proposal.access_route}<br />
-    <strong>Submitted On:</strong> #{proposal.submitted_on}<br />
-    <strong>Principal Investigator:</strong> #{proposal.principal_investigator}, #{proposal.establishment}<br />
-    <strong>Alternate Contact(s):</strong> #{proposal.alternative_contacts ? proposal.alternative_contacts  : 'No AC\'s provided'}<br />
+    <strong>Proposal Reference No:</strong> #{proposal.refNum}<br />
+    <strong>Access Route:</strong> #{proposal.accessRoute}<br />
+    <strong>Submitted On:</strong> #{proposal.submittedOn}<br />
+    <strong>Principal Investigator:</strong> #{proposal.principalInvestigator}, #{proposal.establishment}<br />
+    <strong>Alternate Contact(s):</strong> #{proposal.alternativeContacts ? proposal.alternativeContacts  : 'No AC\'s provided'}<br />
     <strong>Co-investigator(s):</strong> #{proposal.coinvestigators}<br />
     <strong>Requested: </strong> #{proposal.requested}<br />
     <strong>Full Details:</strong> <a href="https://diamond.ac.uk">Click Here (Login required)</a>
 </p>
 
-<p>This proposal will be considered for the allocation period #{allocation_period}, along with the other proposals submitted by #{deadline}.</p>
+<p>This proposal will be considered for the allocation period #{allocationPeriod}, along with the other proposals submitted by #{deadline}.</p>
 
 <p>You will not be able to edit your proposal now it has been submitted. If essential changes are needed, please contact the Diamond User Office by <a href="mailto:useroffice@diamond.ac.uk">email</a>.</p>
 <p>Your details will be stored on a database for use by Diamond Light Source.</p>

--- a/apps/backend/emails/proposal-submitted.subject.pug
+++ b/apps/backend/emails/proposal-submitted.subject.pug
@@ -1,0 +1,1 @@
+= `Proposal Submitted: ${proposal.title}`

--- a/apps/backend/src/config/dependencyConfigDLS.ts
+++ b/apps/backend/src/config/dependencyConfigDLS.ts
@@ -1,8 +1,4 @@
-import {
-  ConsoleLogger,
-  logger,
-  setLogger,
-} from '@user-office-software/duo-logger';
+import { ConsoleLogger, setLogger } from '@user-office-software/duo-logger';
 
 import 'reflect-metadata';
 import { DataAccessUsersAuthorization } from '../auth/DataAccessUsersAuthorization';
@@ -46,14 +42,14 @@ import PostgresUserDataSource from '../datasources/postgres/UserDataSource';
 import PostgresVisitDataSource from '../datasources/postgres/VisitDataSource';
 import PostgresVisitRegistrationClaimDataSource from '../datasources/postgres/VisitRegistrationClaimDataSource';
 import PostgresWorkflowDataSource from '../datasources/postgres/WorkflowDataSource';
+import { dlsEmailHandler } from '../eventHandlers/email/dlsEmailHandler';
 import { createSkipLoggingHandler } from '../eventHandlers/logging';
-import { SkipSendMailService } from '../eventHandlers/MailService/SkipSendMailService';
+import { SMTPMailService } from '../eventHandlers/MailService/SMTPMailService';
 import {
   createListenToRabbitMQHandler,
   createPostToRabbitMQHandler,
 } from '../eventHandlers/messageBroker';
 import { createApplicationEventBus } from '../events';
-import { ApplicationEvent } from '../events/applicationEvents';
 import { FapDataColumns } from '../factory/xlsx/FapDataColumns';
 import {
   callFapPopulateRow,
@@ -65,10 +61,6 @@ import { SkipAssetRegistrar } from '../services/assetRegistrar/skip/SkipAssetReg
 import { configureDLSEnvironment } from './dls/configureDLSEnvironment';
 import { Tokens } from './Tokens';
 import { mapClass, mapValue } from './utils';
-
-async function skipEmailHandler(event: ApplicationEvent) {
-  logger.logInfo('Skip email sending', { event });
-}
 
 mapClass(Tokens.AdminDataSource, PostgresAdminDataSourceWithAutoUpgrade);
 mapClass(Tokens.CoProposerClaimDataSource, PostgresCoProposerClaimDataSource);
@@ -131,14 +123,15 @@ mapClass(Tokens.DataAccessUsersAuthorization, DataAccessUsersAuthorization);
 
 mapClass(Tokens.AssetRegistrar, SkipAssetRegistrar);
 
-mapClass(Tokens.MailService, SkipSendMailService);
+mapClass(Tokens.MailService, SMTPMailService);
 
 mapValue(Tokens.FapDataColumns, FapDataColumns);
 mapValue(Tokens.FapDataRow, getDataRow);
 mapValue(Tokens.PopulateRow, populateRow);
 mapValue(Tokens.PopulateCallRow, callFapPopulateRow);
 
-mapValue(Tokens.EmailEventHandler, skipEmailHandler);
+//mapValue(Tokens.EmailEventHandler, skipEmailHandler);
+mapValue(Tokens.EmailEventHandler, dlsEmailHandler);
 
 mapValue(Tokens.PostToMessageQueue, createPostToRabbitMQHandler());
 mapValue(Tokens.LoggingHandler, createSkipLoggingHandler());

--- a/apps/backend/src/eventHandlers/MailService/MailService.ts
+++ b/apps/backend/src/eventHandlers/MailService/MailService.ts
@@ -5,9 +5,7 @@ export abstract class MailService {
   abstract sendMail(options: EmailSettings): ResultsPromise<SendMailResults>;
   abstract getEmailTemplates(
     includeDraft?: boolean
-  ): ResultsPromise<
-    (SparkPostTemplate | STFCEmailTemplate | ELIEmailTemplate)[]
-  >;
+  ): ResultsPromise<DLSEmailTemplate[]>;
 }
 
 export type SparkPostTemplate = {
@@ -28,6 +26,11 @@ export type STFCEmailTemplate = {
 };
 
 export type ELIEmailTemplate = {
+  id: string;
+  name: string;
+};
+
+export type DLSEmailTemplate = {
   id: string;
   name: string;
 };

--- a/apps/backend/src/eventHandlers/MailService/SMTPMailService.ts
+++ b/apps/backend/src/eventHandlers/MailService/SMTPMailService.ts
@@ -13,7 +13,7 @@ import { AdminDataSource } from '../../datasources/AdminDataSource';
 import { SettingsId } from '../../models/Settings';
 import { isProduction } from '../../utils/helperFunctions';
 import EmailSettings from './EmailSettings';
-import { MailService, STFCEmailTemplate, SendMailResults } from './MailService';
+import { DLSEmailTemplate, MailService, SendMailResults } from './MailService';
 import { ResultsPromise } from './SparkPost';
 
 export class SMTPMailService extends MailService {
@@ -174,52 +174,16 @@ export class SMTPMailService extends MailService {
     });
   }
 
-  async getEmailTemplates(): ResultsPromise<STFCEmailTemplate[]> {
+  async getEmailTemplates(): ResultsPromise<DLSEmailTemplate[]> {
     return {
       results: [
         {
-          id: 'clf-proposal-submitted-pi',
-          name: 'CLF PI Co-I Submission Email',
+          id: 'proposal-submitted',
+          name: 'Proposal Submitted email',
         },
         {
-          id: 'isis-proposal-submitted-pi',
-          name: 'ISIS PI Co-I Submission Email',
-        },
-        {
-          id: 'isis-rapid-proposal-submitted-pi',
-          name: 'ISIS Rapid PI Co-I Submission Email',
-        },
-        {
-          id: 'isis-rapid-proposal-submitted-uo',
-          name: 'ISIS Rapid User Office Submission Email',
-        },
-        {
-          id: 'xpress-proposal-submitted-pi',
-          name: 'ISIS Xpress PI Co-I Submission Email',
-        },
-        {
-          id: 'xpress-proposal-submitted-sc',
-          name: 'ISIS Xpress Scientist Submission Email',
-        },
-        {
-          id: 'xpress-proposal-under-review',
-          name: 'ISIS Xpress PI Co-I Under Review Email',
-        },
-        {
-          id: 'xpress-proposal-approved',
-          name: 'ISIS Xpress PI Co-I Approval Email',
-        },
-        {
-          id: 'xpress-proposal-sra',
-          name: 'ISIS Xpress SRA Request Email',
-        },
-        {
-          id: 'xpress-proposal-unsuccessful',
-          name: 'ISIS Xpress PI Co-I Reject Email',
-        },
-        {
-          id: 'xpress-proposal-finished',
-          name: 'ISIS Xpress PI Co-I Finish Email',
+          id: 'co-proposer-invite',
+          name: 'Invite Co-Proposer email',
         },
       ],
     };

--- a/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
@@ -1,0 +1,178 @@
+import { logger } from '@user-office-software/duo-logger';
+import { container } from 'tsyringe';
+
+import { Tokens } from '../../config/Tokens';
+import { CallDataSource } from '../../datasources/CallDataSource';
+import { InviteDataSource } from '../../datasources/InviteDataSource';
+import { UserDataSource } from '../../datasources/UserDataSource';
+import { ApplicationEvent } from '../../events/applicationEvents';
+import { Event } from '../../events/event.enum';
+import { EventBus } from '../../events/eventBus';
+import EmailSettings from '../MailService/EmailSettings';
+import { MailService } from '../MailService/MailService';
+
+export async function dlsEmailHandler(event: ApplicationEvent) {
+  const userDataSource = container.resolve<UserDataSource>(
+    Tokens.UserDataSource
+  );
+  const callDataSource = container.resolve<CallDataSource>(
+    Tokens.CallDataSource
+  );
+
+  //test for null
+  if (event.isRejection) {
+    return;
+  }
+
+  const mailService = container.resolve<MailService>(Tokens.MailService);
+  const eventBus = container.resolve<EventBus<ApplicationEvent>>(
+    Tokens.EventBus
+  );
+  const inviteDataSource = container.resolve<InviteDataSource>(
+    Tokens.InviteDataSource
+  );
+
+  switch (event.type) {
+    case Event.PROPOSAL_SUBMITTED: {
+      const principalInvestigator = await userDataSource.getUser(
+        event.proposal.proposerId
+      );
+      const participants = await userDataSource.getProposalUsersFull(
+        event.proposal.primaryKey
+      );
+      const call = await callDataSource.getCall(event.proposal.callId);
+
+      const workflow = await callDataSource.getProposalWorkflowByCall(
+        event.proposal.callId
+      );
+
+      if (!principalInvestigator) {
+        return;
+      }
+
+      const options: EmailSettings = {
+        content: {
+          template_id: 'proposal-submitted',
+        },
+        substitution_data: {
+          name: '',
+          proposal: {
+            title: event.proposal.title,
+            ref_num: event.proposal.proposalId,
+            submitted_on: event.proposal.submittedDate!.toLocaleString(),
+            access_route: workflow?.name || 'N/A',
+            principal_investigator:
+              principalInvestigator.preferredname +
+              ' ' +
+              principalInvestigator.lastname,
+            establishment: principalInvestigator.institution,
+            alternative_contacts: '',
+            coinvestigators: participants.map(
+              (partipant) => `${partipant.preferredname} ${partipant.lastname} `
+            ),
+            requested:
+              'MX: Macromolecular Crystallography I03, I04, I04-1 (1 shifts)', // Need to find out what this string is made up of (call instruments and their shifts?)
+          },
+          allocation_period: 'Sept 2026 - Mar 2027', // Need to find out where to get this
+          deadline: call?.endCall,
+        },
+        recipients: [],
+      };
+
+      for (const participant of participants) {
+        if (!participant.email) {
+          logger.logError(
+            'Could not send email on proposal submission: participant has no email',
+            { participant, event }
+          );
+
+          return;
+        }
+
+        (options.substitution_data as any).name = participant.preferredname;
+        options.recipients = [
+          {
+            address: participant.email,
+          },
+        ];
+
+        mailService
+          .sendMail(options)
+          .then((res: any) => {
+            logger.logInfo('Emails sent on proposal submission:', {
+              result: res,
+              event,
+            });
+          })
+          .catch((err: string) => {
+            logger.logError('Could not send email(s) on proposal submission:', {
+              error: err,
+              event,
+            });
+          });
+      }
+
+      return;
+    }
+    case Event.PROPOSAL_CO_PROPOSER_INVITES_UPDATED: {
+      const templateId = 'co-proposer-invite';
+      const invites = event.array;
+
+      for (const invite of invites) {
+        if (invite.isEmailSent) {
+          continue;
+        }
+        const inviter = await userDataSource.getBasicUserInfo(
+          invite.createdByUserId
+        );
+
+        if (!inviter) {
+          logger.logError('No inviter found when trying to send email', {
+            inviter,
+            event,
+          });
+
+          return;
+        }
+
+        const options: EmailSettings = {
+          content: {
+            template_id: templateId,
+          },
+          substitution_data: {
+            sender: inviter.preferredname + ' ' + inviter.lastname,
+          },
+          recipients: [{ address: invite.email }],
+        };
+
+        mailService
+          .sendMail(options)
+          .then(async (res: any) => {
+            logger.logInfo('Emails sent on proposal invite:', {
+              result: res,
+              event,
+            });
+
+            await inviteDataSource.update({
+              id: invite.id,
+              isEmailSent: true,
+              templateId: templateId,
+            });
+
+            await eventBus.publish({
+              ...event,
+              type: Event.PROPOSAL_CO_PROPOSER_INVITE_SENT,
+              invite,
+            });
+          })
+          .catch((err: string) => {
+            logger.logError('Could not send email(s) on proposal invite:', {
+              error: err,
+              event,
+            });
+          });
+      }
+      break;
+    }
+  }
+}

--- a/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
@@ -3,7 +3,9 @@ import { container } from 'tsyringe';
 
 import { Tokens } from '../../config/Tokens';
 import { CallDataSource } from '../../datasources/CallDataSource';
+import { InstrumentDataSource } from '../../datasources/InstrumentDataSource';
 import { InviteDataSource } from '../../datasources/InviteDataSource';
+import { QuestionaryDataSource } from '../../datasources/QuestionaryDataSource';
 import { UserDataSource } from '../../datasources/UserDataSource';
 import { ApplicationEvent } from '../../events/applicationEvents';
 import { Event } from '../../events/event.enum';
@@ -31,24 +33,72 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
   const inviteDataSource = container.resolve<InviteDataSource>(
     Tokens.InviteDataSource
   );
+  const instrumentSource = container.resolve<InstrumentDataSource>(
+    Tokens.InstrumentDataSource
+  );
+  const questionaryDataSource = container.resolve<QuestionaryDataSource>(
+    Tokens.QuestionaryDataSource
+  );
 
   switch (event.type) {
     case Event.PROPOSAL_SUBMITTED: {
       const principalInvestigator = await userDataSource.getUser(
         event.proposal.proposerId
       );
+      if (!principalInvestigator) {
+        return;
+      }
+
       const participants = await userDataSource.getProposalUsersFull(
         event.proposal.primaryKey
       );
+
       const call = await callDataSource.getCall(event.proposal.callId);
+      if (!call) {
+        return;
+      }
 
       const workflow = await callDataSource.getProposalWorkflowByCall(
         event.proposal.callId
       );
 
-      if (!principalInvestigator) {
-        return;
-      }
+      const instruments = await instrumentSource.getInstrumentsByProposalPk(
+        event.proposal.primaryKey
+      );
+
+      // Postgres implementation doesn't match interface - impliementation wants questionaryId, not proposalId
+      const answer = await questionaryDataSource.getAnswer(
+        event.proposal.questionaryId,
+        'instrument_picker'
+      );
+
+      (
+        answer?.answer as {
+          value: { instrumentId: number; timeRequested: number }[];
+        }
+      ).value.forEach((instrumentAnswer: any) => {
+        const instrument = instruments.find(
+          (inst) => inst.id === Number(instrumentAnswer.instrumentId)
+        );
+        if (instrument) {
+          instrument.managementTimeAllocation =
+            instrumentAnswer.timeRequested || 0;
+        }
+      });
+
+      const shortDateFormat = new Intl.DateTimeFormat('en-GB', {
+        month: 'short',
+        year: 'numeric',
+      });
+
+      const longDateFormat = new Intl.DateTimeFormat('en-GB', {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      });
+
+      const allocationPeriod = `${shortDateFormat.format(call.startCycle)} - ${shortDateFormat.format(call.endCycle)}`;
 
       const options: EmailSettings = {
         content: {
@@ -58,26 +108,31 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
           name: '',
           proposal: {
             title: event.proposal.title,
-            ref_num: event.proposal.proposalId,
-            submitted_on: event.proposal.submittedDate!.toLocaleString(),
-            access_route: workflow?.name || 'N/A',
-            principal_investigator:
+            refNum: event.proposal.proposalId,
+            submittedOn: event.proposal.submittedDate!.toLocaleString(),
+            accessRoute: workflow?.name || 'N/A',
+            principalInvestigator:
               principalInvestigator.preferredname +
               ' ' +
               principalInvestigator.lastname,
             establishment: principalInvestigator.institution,
-            alternative_contacts: '',
+            alternativeContacts: '',
             coinvestigators: participants.map(
               (partipant) => `${partipant.preferredname} ${partipant.lastname} `
             ),
-            requested:
-              'MX: Macromolecular Crystallography I03, I04, I04-1 (1 shifts)', // Need to find out what this string is made up of (call instruments and their shifts?)
+            requested: instruments
+              .map((instrument) => {
+                return `${instrument.name}: ${instrument.description} ${instrument.managementTimeAllocation} ${call.allocationTimeUnit}${instrument.managementTimeAllocation > 1 ? 's' : ''}`;
+              })
+              .join(', '),
           },
-          allocation_period: 'Sept 2026 - Mar 2027', // Need to find out where to get this
-          deadline: call?.endCall,
+          allocationPeriod: allocationPeriod,
+          deadline: longDateFormat.format(call.endCall),
         },
         recipients: [],
       };
+
+      participants.push(principalInvestigator); // Ensure PI also gets an email
 
       for (const participant of participants) {
         if (!participant.email) {


### PR DESCRIPTION
This PR adds the email templates to the default location expected by the application (`apps/backend/emails`) and configures the dependency handler to use the DLS specific handler for handling email events.

It uses the `SMTPMailService` which requires the following environment variables to be set:

```
EMAIL_AUTH_HOST=
EMAIL_AUTH_PORT=
EMAIL_SENDER=
```

The application events that are looked for are `PROPOSAL_SUBMITTED` and `PROPOSAL_CO_PROPOSER_INVITES_UPDATED`.