### PR TITLE
UAS-14458: Use new object for each sendMail call

### DIFF
--- a/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
@@ -169,15 +169,30 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
           return;
         }
 
-        (options.substitution_data as any).name = participant.preferredname;
-        options.recipients = [
+        // Create a copy of options for each participant to avoid mutation issues
+        const participantEmailOptions: EmailSettings = {
+          ...options,
+          substitution_data: {
+            ...(options.substitution_data as any),
+            name: participant.preferredname,
+          },
+          recipients: [
+            {
+              address: participant.email,
+            },
+          ],
+        };
+
+        (participantEmailOptions.substitution_data as any).name =
+          participant.preferredname;
+        participantEmailOptions.recipients = [
           {
             address: participant.email,
           },
         ];
 
         mailService
-          .sendMail(options)
+          .sendMail(participantEmailOptions)
           .then((res: any) => {
             logger.logInfo('Emails sent on proposal submission:', {
               result: res,

--- a/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
@@ -183,14 +183,6 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
           ],
         };
 
-        (participantEmailOptions.substitution_data as any).name =
-          participant.preferredname;
-        participantEmailOptions.recipients = [
-          {
-            address: participant.email,
-          },
-        ];
-
         mailService
           .sendMail(participantEmailOptions)
           .then((res: any) => {


### PR DESCRIPTION
Reusing the `options` object with the asynchronous call to `sendMail` was resulting in the proposal submission email being sent to the PI (the last user in the list of participants) for every participant. This fix creates a locally scoped email options object for each mail send.