### PR TITLE
UAS-14536: fix emails for empty pref names

### DIFF
--- a/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
@@ -136,13 +136,15 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
             submittedOn: event.proposal.submittedDate!.toLocaleString(),
             accessRoute: workflow?.name || 'N/A',
             principalInvestigator:
-              principalInvestigator.preferredname +
-              ' ' +
-              principalInvestigator.lastname,
+              principalInvestigator.preferredname ||
+              principalInvestigator.firstname +
+                ' ' +
+                principalInvestigator.lastname,
             establishment: principalInvestigator.institution,
             alternativeContacts: '',
             coinvestigators: participants.map(
-              (partipant) => `${partipant.preferredname} ${partipant.lastname} `
+              (partipant) =>
+                `${partipant.preferredname || partipant.firstname} ${partipant.lastname} `
             ),
             requested: instruments
               .map((instrument) => {
@@ -174,7 +176,7 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
           ...options,
           substitution_data: {
             ...(options.substitution_data as any),
-            name: participant.preferredname,
+            name: participant.preferredname || participant.firstname,
           },
           recipients: [
             {
@@ -237,7 +239,9 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
             template: emailTemplate.id.toString(),
           },
           substitution_data: {
-            sender: inviter.preferredname + ' ' + inviter.lastname,
+            sender:
+              inviter.preferredname ||
+              inviter.firstname + ' ' + inviter.lastname,
             redeem_code: invite.code,
             uos_instance: process.env.BASE_URL,
             uas_instance: getUASInstance(),


### PR DESCRIPTION
This PR uses the peoples firstname if they do not have a preferred name. Note that there is 4 changes and I have indicated each part of the email that they relate to. 

I am using || to check for the truthy-ness of the prefered name value instead of ?? which indicates nullish value because when you have an empty prefered name in the GUI it is not set to null in the database but the empty string.

**BEFORE**
<img width="1712" height="1725" alt="image" src="https://github.com/user-attachments/assets/dea63588-3e6e-4c8c-b8fa-061e4726142f" />

<img width="1657" height="1695" alt="image" src="https://github.com/user-attachments/assets/e81fad14-b1b5-4564-a4cc-334ec987d870" />

**AFTER**

<img width="1667" height="1652" alt="image" src="https://github.com/user-attachments/assets/af95a64d-5eb5-40f0-93a8-6a85208cd65d" />

<img width="1637" height="1742" alt="image" src="https://github.com/user-attachments/assets/59d7119f-fc43-4f65-a96f-2596993b5f6c" />
