### PR TITLE
UAS-14542: Dynamically obtain instrument picker question IDs for proposal submission email

### DIFF
--- a/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
+++ b/apps/backend/src/eventHandlers/email/dlsEmailHandler.ts
@@ -12,9 +12,39 @@ import { UserDataSource } from '../../datasources/UserDataSource';
 import { ApplicationEvent } from '../../events/applicationEvents';
 import { Event } from '../../events/event.enum';
 import { EventBus } from '../../events/eventBus';
+import { getTopicActiveAnswers } from '../../models/ProposalModelFunctions';
+import { Answer, QuestionaryStep } from '../../models/Questionary';
+import { DataType } from '../../models/Template';
 import EmailSettings from '../MailService/EmailSettings';
 import { MailService } from '../MailService/MailService';
 import { EmailTemplateId } from './emailTemplateId';
+
+type InstrumentPickerAnswerValue = {
+  instrumentId: number | string;
+  timeRequested?: number | string | null;
+};
+
+const getInstrumentPickerAnswers = (
+  questionarySteps: QuestionaryStep[]
+): Answer[] =>
+  questionarySteps
+    .flatMap((step) => getTopicActiveAnswers(questionarySteps, step.topic.id))
+    .filter(
+      (answer) => answer.question.dataType === DataType.INSTRUMENT_PICKER
+    );
+
+const getInstrumentPickerAnswerValues = (
+  value: unknown
+): InstrumentPickerAnswerValue[] => {
+  const values = Array.isArray(value) ? value : value ? [value] : [];
+
+  return values.filter(
+    (instrumentAnswer): instrumentAnswer is InstrumentPickerAnswerValue =>
+      typeof instrumentAnswer === 'object' &&
+      instrumentAnswer !== null &&
+      'instrumentId' in instrumentAnswer
+  );
+};
 
 export async function dlsEmailHandler(event: ApplicationEvent) {
   const userDataSource = container.resolve<UserDataSource>(
@@ -69,29 +99,50 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
         event.proposal.callId
       );
 
-      const instruments = await instrumentSource.getInstrumentsByProposalPk(
-        event.proposal.primaryKey
+      const questionarySteps = await questionaryDataSource.getQuestionarySteps(
+        event.proposal.questionaryId
       );
-
-      // Postgres implementation doesn't match interface - impliementation wants questionaryId, not proposalId
-      const answer = await questionaryDataSource.getAnswer(
-        event.proposal.questionaryId,
-        'instrument_picker'
+      const instrumentPickerAnswers =
+        getInstrumentPickerAnswers(questionarySteps);
+      const instrumentPickerAnswerValues = instrumentPickerAnswers.flatMap(
+        (answer) => getInstrumentPickerAnswerValues(answer.value)
       );
+      const instrumentIds = Array.from(
+        new Set(
+          instrumentPickerAnswerValues
+            .map((instrumentAnswer) => Number(instrumentAnswer.instrumentId))
+            .filter((instrumentId) => Number.isFinite(instrumentId))
+        )
+      );
+      const instruments =
+        await instrumentSource.getInstrumentsByIds(instrumentIds);
+      const requested = instrumentPickerAnswerValues
+        .map((instrumentAnswer) => {
+          const requestedTime = Number(instrumentAnswer.timeRequested ?? 0);
+          const formattedRequestedTime = Number.isFinite(requestedTime)
+            ? requestedTime
+            : 0;
+          const instrument = instruments.find(
+            (inst) => inst.id === Number(instrumentAnswer.instrumentId)
+          );
 
-      (
-        answer?.answer as {
-          value: { instrumentId: number; timeRequested: number }[];
-        }
-      )?.value.forEach((instrumentAnswer: any) => {
-        const instrument = instruments.find(
-          (inst) => inst.id === Number(instrumentAnswer.instrumentId)
-        );
-        if (instrument) {
-          instrument.managementTimeAllocation =
-            instrumentAnswer.timeRequested || 0;
-        }
-      });
+          if (!instrument) {
+            return null;
+          }
+
+          const timeUnit = `${call.allocationTimeUnit}${
+            formattedRequestedTime > 1 ? 's' : ''
+          }`;
+
+          return [
+            `${instrument.name}:`,
+            instrument.description,
+            formattedRequestedTime,
+            timeUnit,
+          ].join(' ');
+        })
+        .filter((request): request is string => request !== null)
+        .join(', ');
 
       const shortDateFormat = new Intl.DateTimeFormat('en-GB', {
         month: 'short',
@@ -146,11 +197,7 @@ export async function dlsEmailHandler(event: ApplicationEvent) {
               (partipant) =>
                 `${partipant.preferredname || partipant.firstname} ${partipant.lastname} `
             ),
-            requested: instruments
-              .map((instrument) => {
-                return `${instrument.name}: ${instrument.description} ${instrument.managementTimeAllocation} ${call.allocationTimeUnit}${instrument.managementTimeAllocation > 1 ? 's' : ''}`;
-              })
-              .join(', '),
+            requested,
           },
           allocationPeriod: allocationPeriod,
           deadline: longDateFormat.format(call.endCall),


### PR DESCRIPTION
This PR addresses the bug described in UAS-14542. It dynamically looks for all instrument picker questions in a proposal and attaches their name, description and time requested.

This fix is being applied to the email handler as it currently stands with the big switch statement. I'll apply it separately to the email handler refactor as it stands when synchronising with the upsteam repo.