### PR TITLE
UAS-14414: Change sample answer dialog title

### DIFF
--- a/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/QuestionaryComponentSampleDeclaration.tsx
@@ -211,7 +211,7 @@ function QuestionaryComponentSampleDeclaration(
                 data-cy="sample-declaration-modal"
                 maxWidth="md"
                 fullWidth
-                title="Sample Declaration"
+                title="ERA Component"
               >
                 <DialogContent dividers>
                   {selectedSample ? (

--- a/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/SampleDeclarationContainer.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/SampleDeclarationContainer.tsx
@@ -59,7 +59,7 @@ export function SampleDeclarationContainer(props: {
   return (
     <QuestionaryContext.Provider value={{ state, dispatch }}>
       <Questionary
-        title={state.sample.title || 'New Sample'}
+        title={state.sample.title || ''}
         previewMode={props.previewMode}
       />
     </QuestionaryContext.Provider>

--- a/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/SamplesAnswerRenderer.tsx
+++ b/apps/frontend/src/components/questionary/questionaryComponents/SampleDeclaration/SamplesAnswerRenderer.tsx
@@ -66,7 +66,7 @@ const SamplesAnswerRenderer = ({
         fullWidth
         open={selectedSampleId !== null}
         onClose={() => setSelectedSampleId(null)}
-        title="Sample details"
+        title="ERA Component"
       >
         <DialogContent>
           {selectedSampleId ? (


### PR DESCRIPTION
Because the "sample" template is used for collecting samples, methods and equipment, showing "sample" to the user can be misleading.

This change addresses that by
- changing the title of the dialog that shows the sample answers to "ERA Component",
- changing the title of the dialog of a new sample declaration to "ERA Component",
- Removing "New Sample" from within the body of the dialog for a new sample.